### PR TITLE
feat(ui): Add image lightbox for click-to-zoom on article images

### DIFF
--- a/pages/blog/[id].tsx
+++ b/pages/blog/[id].tsx
@@ -3,7 +3,7 @@ import Head from 'next/head'
 import Layout from '../../components/layout'
 import Date from '../../components/date'
 import { getAllPostIds, getPostData } from '../../lib/posts'
-import { useEffect } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import Prism from 'prismjs'
 
 export async function getStaticProps({
@@ -31,6 +31,42 @@ export default function Post({
     useEffect(() => {
         Prism.highlightAll()
     }, [])
+
+    const [lightbox, setLightbox] = useState<{ src: string; alt: string } | null>(null)
+    const closeButtonRef = useRef<HTMLButtonElement>(null)
+
+    useEffect(() => {
+        const article = document.querySelector('article')
+        if (!article) return
+        const handleClick = (e: MouseEvent) => {
+            const target = e.target as HTMLElement
+            if (target.tagName === 'IMG' && !target.classList.contains('rlc-image')) {
+                const img = target as HTMLImageElement
+                setLightbox({ src: img.src, alt: img.alt })
+            }
+        }
+        article.addEventListener('click', handleClick)
+        return () => article.removeEventListener('click', handleClick)
+    }, [])
+
+    useEffect(() => {
+        if (!lightbox) return
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') setLightbox(null)
+        }
+        document.addEventListener('keydown', handleKeyDown)
+        return () => document.removeEventListener('keydown', handleKeyDown)
+    }, [lightbox])
+
+    useEffect(() => {
+        document.body.style.overflow = lightbox ? 'hidden' : ''
+        return () => { document.body.style.overflow = '' }
+    }, [lightbox])
+
+    useEffect(() => {
+        if (lightbox) closeButtonRef.current?.focus()
+    }, [lightbox])
+
     const pageTitle = postData.title + " - " + "chroju.dev"
     const pageURL = "https://chroju.dev/blog/" + postData.title
 
@@ -52,6 +88,30 @@ export default function Post({
                 </div>
                 <div dangerouslySetInnerHTML={{ __html: postData.contentHtml }} />
             </article>
+            {lightbox && (
+                <div
+                    className="fixed inset-0 z-50 flex items-center justify-center bg-black/75 cursor-zoom-out"
+                    onClick={() => setLightbox(null)}
+                    role="dialog"
+                    aria-modal="true"
+                    aria-label="画像の拡大表示"
+                >
+                    <button
+                        ref={closeButtonRef}
+                        className="absolute top-4 right-4 text-white text-3xl leading-none hover:text-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
+                        onClick={() => setLightbox(null)}
+                        aria-label="閉じる"
+                    >
+                        ×
+                    </button>
+                    <img
+                        src={lightbox.src}
+                        alt={lightbox.alt}
+                        className="max-w-[90vw] max-h-[90vh] object-contain rounded shadow-2xl cursor-auto"
+                        onClick={(e) => e.stopPropagation()}
+                    />
+                </div>
+            )}
         </Layout>
     )
 }

--- a/styles/global.css
+++ b/styles/global.css
@@ -28,7 +28,7 @@
     @apply font-bold mt-3;
   }
   article p img {
-    @apply inline-block mx-auto rounded md:max-w-xl max-w-xs my-8 border-2;
+    @apply inline-block mx-auto rounded md:max-w-xl max-w-xs my-8 border-2 cursor-zoom-in;
   }
   table {
     @apply border-slate-200 border-2;


### PR DESCRIPTION
## Summary

- Add lightbox modal that opens when clicking images in article body
- Images in article display `zoom-in` cursor to indicate they are clickable
- Close modal by clicking outside the image or pressing Escape key
- Link card images (`rlc-image`) are excluded from lightbox behavior

## Changes

- `pages/blog/[id].tsx`: Add `useState`/`useRef`, event delegation on `article` element, Esc key handler, scroll lock, and focus management; add lightbox modal JSX
- `styles/global.css`: Add `cursor-zoom-in` to `article p img` rule

## Test Plan

- [ ] Click an image in an article → lightbox opens
- [ ] Click outside the image in the modal → closes
- [ ] Press Escape → closes
- [ ] Click a link card image → lightbox does NOT open
- [ ] `cursor-zoom-in` appears when hovering over article images

🤖 Generated with [Claude Code](https://claude.com/claude-code)