### PR TITLE
feat: Replace Next.js with a custom static site generator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,15 +9,15 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: npm
 
       # OGP画像キャッシュ（.cache/og/）を保持して再生成を避ける
-      - uses: actions/cache@v4
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .cache/og
           key: og-images-${{ github.sha }}
@@ -30,7 +30,7 @@ jobs:
       # デプロイ前に出力の整合性を検証（壊れた成果物を公開しない）
       - run: npm run check
 
-      - uses: cloudflare/wrangler-action@v3
+      - uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@
 .DS_Store
 tsconfig.tsbuildinfo
 
+# Claude Code local settings
+/.claude/
+
 # debug
 npm-debug.log*
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "rss": "1.2.2",
         "satori": "^0.26.0",
         "shiki": "^4.3.1",
-        "simple-icons": "^16.0.0",
         "unified": "^11.0.5",
         "unist-util-visit": "^5.1.0"
       },
@@ -7493,25 +7492,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/simple-icons": {
-      "version": "16.25.0",
-      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-16.25.0.tgz",
-      "integrity": "sha512-ReYPfbqjkTBovxjerHw2tf6E1rQdaCqNJKaJbd78Mui8w+78xQlE1aDO/2ekID++n8qa+1t+oaueYLeiSoQsIA==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/simple-icons"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/simple-icons"
-        }
-      ],
-      "license": "CC0-1.0",
-      "engines": {
-        "node": ">=0.12.18"
       }
     },
     "node_modules/slice-ansi": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "rss": "1.2.2",
     "satori": "^0.26.0",
     "shiki": "^4.3.1",
-    "simple-icons": "^16.0.0",
     "unified": "^11.0.5",
     "unist-util-visit": "^5.1.0"
   },

--- a/src/assets/code.js
+++ b/src/assets/code.js
@@ -33,23 +33,35 @@
   });
 
   // 記事末尾のアクション行: Markdownソースを取得してコピーする
+  var CROSS_ICON =
+    '<svg viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><path d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/></svg>';
+
+  function flashIcon(btn, icon, className) {
+    btn.innerHTML = icon;
+    btn.classList.add(className);
+    setTimeout(function () {
+      btn.innerHTML = COPY_ICON;
+      btn.classList.remove(className);
+    }, 1500);
+  }
+
   var srcBtn = document.querySelector('.post-copy');
   if (srcBtn) {
     srcBtn.addEventListener('click', function () {
       fetch(srcBtn.dataset.raw)
         .then(function (res) {
+          if (!res.ok) throw new Error(res.status);
           return res.text();
         })
         .then(function (text) {
           return navigator.clipboard.writeText(text);
         })
         .then(function () {
-          srcBtn.innerHTML = CHECK_ICON;
-          srcBtn.classList.add('copied');
-          setTimeout(function () {
-            srcBtn.innerHTML = COPY_ICON;
-            srcBtn.classList.remove('copied');
-          }, 1500);
+          flashIcon(srcBtn, CHECK_ICON, 'copied');
+        })
+        .catch(function () {
+          // 取得もコピーもできなかったことだけ伝える（オフライン等）
+          flashIcon(srcBtn, CROSS_ICON, 'copy-failed');
         });
     });
   }

--- a/src/assets/code.js
+++ b/src/assets/code.js
@@ -31,4 +31,26 @@
     });
     wrap.appendChild(btn);
   });
+
+  // 記事末尾のアクション行: Markdownソースを取得してコピーする
+  var srcBtn = document.querySelector('.post-copy');
+  if (srcBtn) {
+    srcBtn.addEventListener('click', function () {
+      fetch(srcBtn.dataset.raw)
+        .then(function (res) {
+          return res.text();
+        })
+        .then(function (text) {
+          return navigator.clipboard.writeText(text);
+        })
+        .then(function () {
+          srcBtn.innerHTML = CHECK_ICON;
+          srcBtn.classList.add('copied');
+          setTimeout(function () {
+            srcBtn.innerHTML = COPY_ICON;
+            srcBtn.classList.remove('copied');
+          }, 1500);
+        });
+    });
+  }
 })();

--- a/src/assets/crumb.js
+++ b/src/assets/crumb.js
@@ -1,0 +1,16 @@
+// パンくずのrecent postsプルダウン: 外側クリックとEscapeで閉じる
+(function () {
+  var menu = document.querySelector('.crumb-recent');
+  if (!menu) return;
+
+  document.addEventListener('click', function (e) {
+    if (menu.open && !menu.contains(e.target)) menu.open = false;
+  });
+
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape' && menu.open) {
+      menu.open = false;
+      menu.querySelector('summary').focus();
+    }
+  });
+})();

--- a/src/build.ts
+++ b/src/build.ts
@@ -96,7 +96,7 @@ export async function buildAll(options: BuildOptions = {}): Promise<void> {
   const mdSlugPosts: string[] = []
   for (const post of publishedPosts) {
     const rendered = renderedById.get(post.id)!
-    write(`blog/${post.id}.html`, postPage(post, rendered.html, rendered.headings))
+    write(`blog/${post.id}.html`, postPage(post, rendered.html, rendered.headings, publishedPosts))
     fs.copyFileSync(
       path.join(root, 'posts', `${post.id}.md`),
       path.join(distDir, 'blog', `${post.id}.md`)

--- a/src/seo.ts
+++ b/src/seo.ts
@@ -77,9 +77,15 @@ export function postDescription(post: Post, maxLength = 120): string {
   return text.length > maxLength ? `${text.slice(0, maxLength)}…` : text
 }
 
-/** 記事ページ用の JSON-LD (BlogPosting) */
+// script終端タグの混入を防ぐ
+function jsonLdScript(data: object): string {
+  const json = JSON.stringify(data).replace(/</g, '\\u003c')
+  return `<script type="application/ld+json">${json}</script>`
+}
+
+/** 記事ページ用の JSON-LD (BlogPosting + BreadcrumbList) */
 export function blogPostingJsonLd(post: Post): string {
-  const data = {
+  const posting = {
     '@context': 'https://schema.org',
     '@type': 'BlogPosting',
     headline: post.title,
@@ -89,7 +95,15 @@ export function blogPostingJsonLd(post: Post): string {
     image: `${site.url}/og/${encodeURIComponent(post.id)}.png`,
     keywords: post.tags.join(','),
   }
-  // script終端タグの混入を防ぐ
-  const json = JSON.stringify(data).replace(/</g, '\\u003c')
-  return `<script type="application/ld+json">${json}</script>`
+  // 記事フッターのパンくず（chroju.dev / blog / 記事）と同じ階層
+  const breadcrumb = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: site.name, item: site.url },
+      { '@type': 'ListItem', position: 2, name: 'blog', item: `${site.url}/blog` },
+      { '@type': 'ListItem', position: 3, name: post.title },
+    ],
+  }
+  return jsonLdScript(posting) + jsonLdScript(breadcrumb)
 }

--- a/src/templates/html.ts
+++ b/src/templates/html.ts
@@ -1,5 +1,4 @@
 import { site } from '../config.ts'
-import { siGithub } from 'simple-icons'
 
 export function escapeHtml(s: string): string {
   return s
@@ -48,25 +47,10 @@ export function formatDate(dateString: string): string {
   return t ? `${d} ${t}` : d
 }
 
-function simpleIcon(icon: { title: string; path: string }, className = 'icon'): Raw {
-  return raw(
-    `<svg class="${className}" role="img" viewBox="0 0 24 24" aria-label="${escapeHtml(
-      icon.title
-    )}" xmlns="http://www.w3.org/2000/svg"><path d="${icon.path}"/></svg>`
-  )
-}
-
 const icons = {
   rss: raw(
     '<svg class="icon" viewBox="0 0 24 24" aria-label="RSS" role="img" xmlns="http://www.w3.org/2000/svg"><path d="M6.18 15.64a2.18 2.18 0 0 1 2.18 2.18C8.36 19 7.38 20 6.18 20 5 20 4 19 4 17.82a2.18 2.18 0 0 1 2.18-2.18M4 4.44A15.56 15.56 0 0 1 19.56 20h-2.83A12.73 12.73 0 0 0 4 7.27zm0 5.66a9.9 9.9 0 0 1 9.9 9.9h-2.83A7.07 7.07 0 0 0 4 12.93z"/></svg>'
   ),
-  file: raw(
-    '<svg class="icon" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><path d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"/></svg>'
-  ),
-  history: raw(
-    '<svg class="icon" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><path d="M13 3a9 9 0 0 0-9 9H1l3.89 3.89.07.14L9 12H6a7 7 0 1 1 7 7c-1.93 0-3.68-.79-4.94-2.06l-1.42 1.42A8.96 8.96 0 0 0 13 21a9 9 0 0 0 0-18zm-1 5v5l4.28 2.54.72-1.21-3.5-2.08V8H12z"/></svg>'
-  ),
-  github: simpleIcon(siGithub, 'icon'),
   sun: raw(
     '<svg class="icon icon-sun" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><path d="M12 7a5 5 0 1 0 0 10 5 5 0 0 0 0-10zm0-5a1 1 0 0 1 1 1v2a1 1 0 1 1-2 0V3a1 1 0 0 1 1-1zm0 18a1 1 0 0 1 1 1v2a1 1 0 1 1-2 0v-2a1 1 0 0 1 1-1zm10-8a1 1 0 0 1-1 1h-2a1 1 0 1 1 0-2h2a1 1 0 0 1 1 1zM6 12a1 1 0 0 1-1 1H3a1 1 0 1 1 0-2h2a1 1 0 0 1 1 1zm12.07 7.07a1 1 0 0 1-1.41 0l-1.42-1.41a1 1 0 0 1 1.42-1.42l1.41 1.42a1 1 0 0 1 0 1.41zM8.76 8.76a1 1 0 0 1-1.42 0L5.93 7.34a1 1 0 0 1 1.41-1.41l1.42 1.41a1 1 0 0 1 0 1.42zm9.31-2.83a1 1 0 0 1 0 1.41L16.66 8.76a1 1 0 1 1-1.42-1.42l1.42-1.41a1 1 0 0 1 1.41 0zM8.76 15.24a1 1 0 0 1 0 1.42l-1.42 1.41a1 1 0 0 1-1.41-1.41l1.41-1.42a1 1 0 0 1 1.42 0z"/></svg>'
   ),
@@ -88,8 +72,6 @@ export interface PageMeta {
   ogImage: string
   /** ブログ系ページか（RSS alternateとサブタイトルの表示） */
   isBlog?: boolean
-  /** 記事ページの場合の記事ID（フッターのEdit/Historyリンクに使用） */
-  articleId?: string
   footer?: boolean
   /** 追加で読み込むスクリプト（記事ページのlightbox等） */
   scripts?: string[]
@@ -111,25 +93,6 @@ export function layout(meta: PageMeta, body: string): string {
   const headerLink = segment ? `/${segment}` : '/'
   const isBlog = meta.isBlog ?? siteTitle === site.blogTitle
   const showFooter = meta.footer ?? true
-  const articleFooter =
-    meta.articleId !== undefined && meta.articleId !== ''
-      ? html`
-          <div class="article-footer">
-            <a class="read-more" href="/blog">Read more articles →</a>
-            <nav class="article-meta-links">
-              <a href="/blog/${raw(encodeURI(meta.articleId))}.md"
-                >${icons.file} Raw</a
-              >
-              <a href="${site.repoURL}/edit/main/posts/${meta.articleId}.md"
-                >${icons.github} Edit</a
-              >
-              <a href="${site.repoURL}/commits/main/posts/${meta.articleId}.md"
-                >${icons.history} History</a
-              >
-            </nav>
-          </div>
-        `
-      : ''
 
   return html`<!doctype html>
 <html lang="ja">
@@ -177,7 +140,6 @@ ${
   showFooter
     ? raw(html`
 <footer class="site-footer">
-${raw(articleFooter)}
 <div class="footer-profile">
 <img src="/images/profile.webp" width="40" height="40" alt="${site.author}">
 <a class="footer-site" href="/">${site.name}</a>

--- a/src/templates/html.ts
+++ b/src/templates/html.ts
@@ -1,5 +1,5 @@
 import { site } from '../config.ts'
-import { siGithub, siActivitypub, siBluesky, siX } from 'simple-icons'
+import { siGithub } from 'simple-icons'
 
 export function escapeHtml(s: string): string {
   return s
@@ -48,7 +48,7 @@ export function formatDate(dateString: string): string {
   return t ? `${d} ${t}` : d
 }
 
-function simpleIcon(icon: { title: string; path: string }, className = 'sns-icon'): Raw {
+function simpleIcon(icon: { title: string; path: string }, className = 'icon'): Raw {
   return raw(
     `<svg class="${className}" role="img" viewBox="0 0 24 24" aria-label="${escapeHtml(
       icon.title
@@ -185,12 +185,6 @@ ${raw(articleFooter)}
 <a href="/blog">/blog</a>
 <a href="/bio">/bio</a>
 <a href="/policy">/policy</a>
-</nav>
-<nav class="footer-sns">
-<a href="https://github.com/chroju">${simpleIcon(siGithub)}</a>
-<a href="https://pleroma.chroju.dev/users/chroju">${simpleIcon(siActivitypub)}</a>
-<a href="https://bsky.app/profile/chroju.dev">${simpleIcon(siBluesky)}</a>
-<a href="https://x.com/chroju">${simpleIcon(siX)}</a>
 </nav>
 </div>
 </footer>`)

--- a/src/templates/pages.ts
+++ b/src/templates/pages.ts
@@ -188,6 +188,39 @@ export function tagPage(encodedTag: string, posts: Post[]): string {
   )
 }
 
+// bio用のfrontmatter風メタブロック（location / expertise / social）
+function bioFrontmatterBlock(): string {
+  const expertise = ['Infrastructure as Code', 'Security', 'Cloud Architecture', 'Engineering Management']
+  const socialLinks: [string, string, string][] = [
+    ['github', 'chroju', 'https://github.com/chroju'],
+    ['activitypub', '@chroju@pleroma.chroju.dev', 'https://pleroma.chroju.dev/users/chroju'],
+    ['bluesky', '@chroju.dev', 'https://bsky.app/profile/chroju.dev'],
+    ['x', '@chroju', 'https://x.com/chroju'],
+  ]
+  return html`
+    <div class="post-frontmatter bio-frontmatter">
+      <span class="fm-delim" aria-hidden="true">---</span>
+      <span class="fm-line"><span class="fm-key">location:</span> Kanagawa, Japan</span>
+      <span class="fm-line"><span class="fm-key">expertise:</span></span>
+      ${raw(
+        expertise
+          .map((item) => html`<span class="fm-line fm-nested fm-list-item">${item}</span>`)
+          .join('')
+      )}
+      <span class="fm-line"><span class="fm-key">social:</span></span>
+      ${raw(
+        socialLinks
+          .map(
+            ([key, label, href]) =>
+              html`<span class="fm-line fm-nested"><span class="fm-key">${key}:</span> <a href="${href}">${label}</a></span>`
+          )
+          .join('')
+      )}
+      <span class="fm-delim" aria-hidden="true">---</span>
+    </div>
+  `
+}
+
 export function bioPage(): string {
   const body = html`
     <article class="bio">
@@ -198,12 +231,7 @@ export function bioPage(): string {
           <p class="bio-role">Site Reliability Engineer</p>
         </div>
       </div>
-      <dl class="bio-facts">
-        <dt>location</dt>
-        <dd>Kanagawa, Japan</dd>
-        <dt>favorite</dt>
-        <dd>Terraform / Kubernetes / Go / AWS</dd>
-      </dl>
+      ${raw(bioFrontmatterBlock())}
       <section>
         <h2>Experience</h2>
         <ol class="timeline">

--- a/src/templates/pages.ts
+++ b/src/templates/pages.ts
@@ -373,7 +373,7 @@ export function policyPage(): string {
     <section>
       <h2>Contact</h2>
       <p>このサイトに関するご意見、ご質問等は、ソースコードをホストしている GitHub レポジトリ <a href="https://github.com/chroju/blog/issues">chroju/blog の Issue</a> で受け付けています。また、ブログ内の記事の修正依頼については、記事末尾の鉛筆アイコンから GitHub 上で Pull Request を作成いただくことができます。</p>
-      <p>chroju へ直接連絡を取りたい場合は、 Twitter の <a href="https://twitter.com/chroju">@chroju</a> までメンションもしくは DM にてご連絡ください。</p>
+      <p>chroju へ直接連絡を取りたい場合は、 Bluesky の <a href="https://bsky.app/profile/chroju.dev">@chroju.dev</a> もしくは X の <a href="https://x.com/chroju">@chroju</a> まで DM にてご連絡ください。</p>
     </section>
   `
   return layout(

--- a/src/templates/pages.ts
+++ b/src/templates/pages.ts
@@ -83,8 +83,8 @@ export function blogIndexPage(posts: Post[]): string {
 function fmTocBlock(headings: Heading[]): string {
   if (headings.length < 3) return ''
   return html`
-    <details class="fm-toc">
-      <summary><span class="fm-key">toc:</span> <span class="fm-toc-hint">[...]</span></summary>
+    <details class="fm-fold fm-toc">
+      <summary><span class="fm-key">toc:</span> <span class="fm-fold-hint">[...]</span></summary>
       <ol>
         ${raw(
           headings
@@ -124,6 +124,26 @@ function frontmatterBlock(post: Post, headings: Heading[] = []): string {
   `
 }
 
+// 記事末尾のアクション行。GitHubのファイルビュー右上の並び（Raw・コピー・編集）を、
+// コードブロックのコピーボタンと同じゴーストボタンの語彙で再構成する
+function postActions(post: Post): string {
+  // コピーアイコンは code.js の COPY_ICON と同一（クリック時の差し替えもcode.js側で行う）
+  const copyIcon = raw(
+    '<svg viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg>'
+  )
+  const editIcon = raw(
+    '<svg viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/></svg>'
+  )
+  const rawPath = `/blog/${encodeURI(post.id)}.md`
+  return html`
+    <div class="post-actions">
+      <a class="post-action" href="${rawPath}" title="Markdownソースを表示">Raw</a>
+      <button class="post-action post-copy" type="button" data-raw="${rawPath}" title="Markdownソースをコピー" aria-label="Markdownソースをコピー">${copyIcon}</button>
+      <a class="post-action" href="${site.repoURL}/edit/main/posts/${post.id}.md" title="GitHubで修正を提案する" aria-label="GitHubで修正を提案する">${editIcon}</a>
+    </div>
+  `
+}
+
 export function postPage(post: Post, contentHtml: string, headings: Heading[] = []): string {
   const pageTitle = `${post.title} - ${site.name}`
   const body = html`
@@ -131,6 +151,7 @@ export function postPage(post: Post, contentHtml: string, headings: Heading[] = 
       <h1 class="post-title">${post.title}</h1>
       ${raw(frontmatterBlock(post, headings))}
       <div class="post-body">${raw(contentHtml)}</div>
+      ${raw(postActions(post))}
     </article>
   `
   return layout(
@@ -139,7 +160,6 @@ export function postPage(post: Post, contentHtml: string, headings: Heading[] = 
       url: `${site.url}/blog/${encodeURI(post.id)}`,
       description: postDescription(post),
       ogImage: `${site.url}/og/${encodeURIComponent(post.id)}.png`,
-      articleId: post.id,
       scripts: ['/js/lightbox.js', '/js/code.js'],
       extraHead: blogPostingJsonLd(post),
     },
@@ -306,7 +326,7 @@ export function policyPage(): string {
     </section>
     <section>
       <h2>Contact</h2>
-      <p>このサイトに関するご意見、ご質問等は、ソースコードをホストしている GitHub レポジトリ <a href="https://github.com/chroju/blog/issues">chroju/blog の Issue</a> で受け付けています。また、ブログ内の記事の修正依頼については、記事下部に記載されている「Edit this article」のリンクから Pull Request を作成いただくことができます。</p>
+      <p>このサイトに関するご意見、ご質問等は、ソースコードをホストしている GitHub レポジトリ <a href="https://github.com/chroju/blog/issues">chroju/blog の Issue</a> で受け付けています。また、ブログ内の記事の修正依頼については、記事末尾の鉛筆アイコンから GitHub 上で Pull Request を作成いただくことができます。</p>
       <p>chroju へ直接連絡を取りたい場合は、 Twitter の <a href="https://twitter.com/chroju">@chroju</a> までメンションもしくは DM にてご連絡ください。</p>
     </section>
   `

--- a/src/templates/pages.ts
+++ b/src/templates/pages.ts
@@ -124,6 +124,44 @@ function frontmatterBlock(post: Post, headings: Heading[] = []): string {
   `
 }
 
+// 記事末尾のパンくず。パスの各階層がリンクで、末尾の▾を押すと
+// IDEのbreadcrumbのように同階層のファイル（最近の記事）が上方向に開く
+// （▾は「メニューがある」の記号なので、開く方向が上でも閉状態は▾で示す）
+function postBreadcrumb(post: Post, allPosts: Post[]): string {
+  const folderIcon = raw(
+    '<svg class="crumb-icon" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><path d="M10 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8l-2-2z"/></svg>'
+  )
+  const sep = raw('<span class="crumb-sep" aria-hidden="true">/</span>')
+  const recent = allPosts.filter((p) => p.id !== post.id).slice(0, 5)
+  return html`
+    <nav class="post-crumb" aria-label="現在地">
+      ${folderIcon}
+      <a href="/">chroju.dev</a>
+      ${sep}
+      <a href="/blog">blog</a>
+      ${sep}
+      <span class="crumb-current">${post.id}.md</span>
+      <details class="crumb-recent">
+        <summary aria-label="最近の記事を表示"><span class="crumb-caret" aria-hidden="true">▾</span></summary>
+        <div class="crumb-panel">
+          <p class="crumb-panel-label">recent posts</p>
+          <ul>
+            ${raw(
+              recent
+                .map(
+                  (p) =>
+                    html`<li><a href="/blog/${raw(encodeURI(p.id))}"><span class="crumb-post-title">${p.title}</span><time datetime="${p.date}">${p.date.slice(0, 10)}</time></a></li>`
+                )
+                .join('')
+            )}
+            <li class="crumb-all"><a href="/blog">All articles →</a></li>
+          </ul>
+        </div>
+      </details>
+    </nav>
+  `
+}
+
 // 記事末尾のアクション行。GitHubのファイルビュー右上の並び（Raw・コピー・編集）を、
 // コードブロックのコピーボタンと同じゴーストボタンの語彙で再構成する
 function postActions(post: Post): string {
@@ -144,14 +182,22 @@ function postActions(post: Post): string {
   `
 }
 
-export function postPage(post: Post, contentHtml: string, headings: Heading[] = []): string {
+export function postPage(
+  post: Post,
+  contentHtml: string,
+  headings: Heading[] = [],
+  allPosts: Post[] = []
+): string {
   const pageTitle = `${post.title} - ${site.name}`
   const body = html`
     <article>
       <h1 class="post-title">${post.title}</h1>
       ${raw(frontmatterBlock(post, headings))}
       <div class="post-body">${raw(contentHtml)}</div>
-      ${raw(postActions(post))}
+      <div class="post-footer">
+        ${raw(postBreadcrumb(post, allPosts))}
+        ${raw(postActions(post))}
+      </div>
     </article>
   `
   return layout(
@@ -160,7 +206,7 @@ export function postPage(post: Post, contentHtml: string, headings: Heading[] = 
       url: `${site.url}/blog/${encodeURI(post.id)}`,
       description: postDescription(post),
       ogImage: `${site.url}/og/${encodeURIComponent(post.id)}.png`,
-      scripts: ['/js/lightbox.js', '/js/code.js'],
+      scripts: ['/js/lightbox.js', '/js/code.js', '/js/crumb.js'],
       extraHead: blogPostingJsonLd(post),
     },
     body

--- a/styles/site.css
+++ b/styles/site.css
@@ -580,6 +580,46 @@ section[data-footnotes] h2 {
   color: var(--text-muted);
 }
 
+/* 記事末尾のアクション行。GitHubのファイルビュー右上の並び（Raw・コピー・編集）を、
+ * コードブロックのコピーボタンと同じゴーストボタンの語彙で置く */
+.post-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  margin: 3rem 0 0;
+}
+
+.post-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.9rem;
+  height: 1.9rem;
+  padding: 0 0.45rem;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  background: none;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.post-action svg {
+  width: 0.95rem;
+  height: 0.95rem;
+  fill: currentColor;
+}
+
+.post-action:hover {
+  color: var(--accent);
+  background: var(--bg-subtle);
+}
+
+.post-copy.copied {
+  color: var(--accent);
+}
+
 article p img {
   display: block;
   margin: 2rem auto;
@@ -646,33 +686,36 @@ article p img {
 }
 
 
-/* ---------- table of contents ---------- */
-/* 目次はfrontmatterの toc: キー。閉じているときは toc: [...] の1行、
- * 開くとYAMLのリスト記法（ハイフン + ネストインデント）で並ぶ */
+/* ---------- frontmatter folds ---------- */
+/* toc: や source: は畳み込み可能なfrontmatterキー。閉じているときは
+ * key: [...] の1行、開くと中身が展開される */
 
-.fm-toc summary {
+.fm-fold summary {
   cursor: pointer;
   /* 開閉は三角マーカーではなく [...] で示す */
   list-style: none;
 }
 
-.fm-toc summary::-webkit-details-marker {
+.fm-fold summary::-webkit-details-marker {
   display: none;
 }
 
 /* クリックできる値はtagsのリンクと同じくアクセント色で示す */
-.fm-toc .fm-toc-hint {
+.fm-fold .fm-fold-hint {
   color: var(--accent);
 }
 
-.fm-toc summary:hover .fm-toc-hint {
+.fm-fold summary:hover .fm-fold-hint {
   text-decoration: underline;
   text-underline-offset: 0.2em;
 }
 
-.fm-toc[open] .fm-toc-hint {
+.fm-fold[open] .fm-fold-hint {
   display: none;
 }
+
+/* ---------- table of contents ---------- */
+/* 目次を開くとYAMLのリスト記法（ハイフン + ネストインデント）で並ぶ */
 
 .fm-toc ol {
   list-style: none;
@@ -919,7 +962,7 @@ main .home-recent h2 {
   margin: 2rem 0;
 }
 
-.bio-frontmatter .fm-nested {
+.post-frontmatter .fm-nested {
   padding-inline-start: 1.5rem;
 }
 
@@ -990,41 +1033,6 @@ main .home-recent h2 {
 .site-footer {
   margin-top: 5rem;
   font-size: 0.9rem;
-}
-
-.article-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 1rem;
-  margin-bottom: 2rem;
-}
-
-.article-meta-links {
-  display: flex;
-  gap: 1rem;
-}
-
-.article-meta-links a {
-  color: var(--text-muted);
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  font-size: 0.9rem;
-}
-
-.article-meta-links a:hover {
-  color: var(--accent);
-}
-
-.article-meta-links .icon {
-  width: 0.9rem;
-  height: 0.9rem;
-  fill: currentColor;
-}
-
-.read-more {
-  font-weight: 600;
 }
 
 .footer-profile {
@@ -1107,8 +1115,7 @@ main .home-recent h2 {
     padding-inline-start: 1.35rem;
   }
 
-  /* Edit/History・RSS・サブタイトルはモバイルでは非表示 */
-  .article-meta-links,
+  /* RSS・サブタイトルはモバイルでは非表示 */
   .rss-link,
   .site-subtitle {
     display: none;
@@ -1172,11 +1179,6 @@ main .home-recent h2 {
 
   .lightbox-close {
     padding: 0.75rem 1.25rem;
-  }
-
-  .read-more {
-    display: inline-block;
-    padding-block: 0.5rem;
   }
 }
 

--- a/styles/site.css
+++ b/styles/site.css
@@ -914,27 +914,19 @@ main .home-recent h2 {
   color: var(--text-muted);
 }
 
-/* 事実リスト: キーをfrontmatter風の等幅で */
-.bio-facts {
-  display: grid;
-  grid-template-columns: max-content 1fr;
-  gap: 0.4rem 1.5rem;
+/* 事実ブロック: 記事のfrontmatterと同じ見た目（---区切り・fm-key等幅） */
+.bio-frontmatter {
   margin: 2rem 0;
 }
 
-.bio-facts dt {
-  font-family: var(--font-mono);
-  font-weight: 400;
+.bio-frontmatter .fm-nested {
+  padding-inline-start: 1.5rem;
+}
+
+/* expertiseはYAMLのリスト記法（ハイフン）で並べる */
+.bio-frontmatter .fm-list-item::before {
+  content: "- ";
   color: var(--text-muted);
-  margin: 0;
-}
-
-.bio-facts dt::after {
-  content: ":";
-}
-
-.bio-facts dd {
-  margin: 0;
 }
 
 /* 経歴タイムライン: 等幅の期間 + 内容の2カラム */
@@ -1056,8 +1048,7 @@ main .home-recent h2 {
   color: var(--text);
 }
 
-.footer-nav,
-.footer-sns {
+.footer-nav {
   display: flex;
   gap: 1rem;
   align-items: center;
@@ -1067,10 +1058,7 @@ main .home-recent h2 {
   .footer-nav {
     border-inline-start: 1px solid var(--border);
     padding-inline-start: 1.5rem;
-  }
-
-  /* SNSアイコンはヘッダーのアクション群と同じく右端に寄せる */
-  .footer-sns {
+    /* SNSアイコンを廃止した分、ナビをヘッダーのアクション群と同じく右端に寄せる */
     margin-inline-start: auto;
   }
 }
@@ -1079,17 +1067,6 @@ main .home-recent h2 {
   font-family: var(--font-mono);
   font-size: 0.85rem;
   color: var(--text);
-}
-
-.sns-icon {
-  width: 1.35rem;
-  height: 1.35rem;
-  fill: var(--text-muted);
-  vertical-align: middle;
-}
-
-a:hover .sns-icon {
-  fill: var(--accent);
 }
 
 /* ---------- narrow screens ---------- */
@@ -1146,8 +1123,7 @@ a:hover .sns-icon {
     padding-block: 0.5rem;
   }
 
-  .footer-nav,
-  .footer-sns {
+  .footer-nav {
     justify-content: center;
     gap: 1.5rem;
   }
@@ -1182,17 +1158,11 @@ a:hover .sns-icon {
     padding-block: 0.25rem;
   }
 
-  .footer-nav a,
-  .footer-sns a {
+  .footer-nav a {
     display: inline-flex;
     align-items: center;
     justify-content: center;
     padding: 0.6rem 0.4rem;
-  }
-
-  .footer-sns .sns-icon {
-    width: 1.5rem;
-    height: 1.5rem;
   }
 
   .tree a {

--- a/styles/site.css
+++ b/styles/site.css
@@ -1281,7 +1281,8 @@ main .home-recent h2 {
     align-items: center;
     gap: 0.85rem;
     text-align: center;
-    padding-block: 0.5rem;
+    /* 罫線とアイコンの間はデスクトップと同じ余白を保つ */
+    padding-block: 1.5rem 0.5rem;
   }
 
   .footer-nav {

--- a/styles/site.css
+++ b/styles/site.css
@@ -544,6 +544,161 @@ section[data-footnotes] h2 {
   line-height: 1.5;
 }
 
+/* 記事フッター: 左にパンくず、右にアクション行を1本のバーとして並べる */
+.post-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.5rem 1.5rem;
+  margin: 3rem 0 0;
+}
+
+/* 記事末尾のパンくず: パスの各階層がリンク、末尾の▴で最近の記事が上に開く */
+.post-crumb {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  min-width: 0;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.post-crumb a {
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.post-crumb a:hover {
+  color: var(--accent);
+}
+
+.crumb-icon {
+  width: 1rem;
+  height: 1rem;
+  fill: currentColor;
+  flex-shrink: 0;
+}
+
+.crumb-sep {
+  color: color-mix(in srgb, var(--text-muted) 50%, transparent);
+  user-select: none;
+}
+
+/* 現在地（ファイル名）は非リンク。長いslugは省略記号で切る */
+.crumb-current {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.crumb-recent {
+  flex-shrink: 0;
+}
+
+.crumb-recent summary {
+  cursor: pointer;
+  list-style: none;
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+}
+
+.crumb-recent summary::-webkit-details-marker {
+  display: none;
+}
+
+.crumb-recent summary:hover {
+  color: var(--accent);
+  background: var(--bg-subtle);
+}
+
+/* 開いている間は反転して「上に出ている」ことを示す */
+.crumb-caret {
+  display: inline-block;
+  transition: transform 0.15s ease;
+}
+
+.crumb-recent[open] .crumb-caret {
+  transform: rotate(180deg);
+}
+
+.crumb-panel {
+  position: absolute;
+  bottom: calc(100% + 0.4rem);
+  left: 0;
+  width: min(26rem, calc(100vw - 2 * var(--pad, 1.1rem)));
+  z-index: 10;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 6px 24px var(--shadow);
+  padding: 0.4rem 0;
+}
+
+.crumb-panel-label {
+  margin: 0;
+  padding: 0.25rem 0.9rem 0.35rem;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  border-bottom: 1px solid var(--border);
+}
+
+.crumb-panel ul {
+  list-style: none;
+  margin: 0;
+  padding: 0.25rem 0 0 !important;
+}
+
+.crumb-panel li {
+  margin: 0;
+}
+
+.crumb-panel a {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.35rem 0.9rem;
+  color: var(--text);
+  /* 記事タイトルは本文の書体で読ませる */
+  font-family: "Helvetica Neue", Arial, "Hiragino Sans",
+    "Hiragino Kaku Gothic ProN", "BIZ UDPGothic", Meiryo, sans-serif;
+  font-size: 0.85rem;
+  line-height: 1.6;
+}
+
+.crumb-panel a:hover {
+  background: var(--bg-subtle);
+  text-decoration: none;
+  color: var(--accent);
+}
+
+.crumb-post-title {
+  min-width: 0;
+}
+
+.crumb-panel time {
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.crumb-all {
+  border-top: 1px solid var(--border);
+  margin-top: 0.25rem !important;
+  padding-top: 0.25rem;
+}
+
+.crumb-all a {
+  font-family: var(--font-mono);
+  color: var(--accent);
+}
+
 /* frontmatter風メタブロック（date / tags） */
 .post-frontmatter {
   font-family: var(--font-mono);
@@ -586,7 +741,6 @@ section[data-footnotes] h2 {
   display: flex;
   align-items: center;
   gap: 0.3rem;
-  margin: 3rem 0 0;
 }
 
 .post-action {

--- a/styles/site.css
+++ b/styles/site.css
@@ -17,6 +17,8 @@
   --shadow: rgba(30, 30, 30, 0.08);
   --font-mono: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas,
     "BIZ UDGothic", monospace;
+  --font-sans: "Helvetica Neue", Arial, "Hiragino Sans",
+    "Hiragino Kaku Gothic ProN", "BIZ UDPGothic", Meiryo, sans-serif;
 }
 
 :root[data-theme="dark"] {
@@ -57,8 +59,7 @@ body {
   margin: 0;
   background: var(--bg);
   color: var(--text);
-  font-family: "Helvetica Neue", Arial, "Hiragino Sans",
-    "Hiragino Kaku Gothic ProN", "BIZ UDPGothic", Meiryo, sans-serif;
+  font-family: var(--font-sans);
   font-size: 1rem;
   line-height: 1.9;
   letter-spacing: 0.02em;
@@ -665,8 +666,7 @@ section[data-footnotes] h2 {
   padding: 0.35rem 0.9rem;
   color: var(--text);
   /* 記事タイトルは本文の書体で読ませる */
-  font-family: "Helvetica Neue", Arial, "Hiragino Sans",
-    "Hiragino Kaku Gothic ProN", "BIZ UDPGothic", Meiryo, sans-serif;
+  font-family: var(--font-sans);
   font-size: 0.85rem;
   line-height: 1.6;
 }

--- a/styles/site.css
+++ b/styles/site.css
@@ -774,6 +774,11 @@ section[data-footnotes] h2 {
   color: var(--accent);
 }
 
+/* コピー失敗時の✕はテーマのアクセントではなく注意色で示す */
+.post-copy.copy-failed {
+  color: #c25757;
+}
+
 article p img {
   display: block;
   margin: 2rem auto;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,6 +2,10 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "chroju-dev",
   "compatibility_date": "2026-07-01",
+  // chroju.dev をこのWorkerのcustom domainにする（DNSレコードと証明書はCloudflareが管理）
+  "routes": [{ "pattern": "chroju.dev", "custom_domain": true }],
+  // custom domain設定後もworkers.devのプレビューURLは残す
+  "workers_dev": true,
   "assets": {
     // 末尾スラッシュなしのパーマリンクを維持する:
     // /blog/foo は blog/foo.html から配信され、/blog/foo/ は /blog/foo へ301される


### PR DESCRIPTION
## Summary

- Remove Next.js/React entirely and rebuild the site as a zero-framework static site generator (Node 24 native TypeScript + unified/remark, ~14 runtime deps, no framework)
- Preserve every permalink (270 posts, tags, RSS at the same URLs, no trailing slash) via flat `blog/{slug}.html` output matching Cloudflare's `drop-trailing-slash` asset resolution
- Redesign from scratch around a "world as code" motif: frontmatter-style post metadata, markdown-style heading anchors (`##`/`###`), tree-style home navigation, monospace path elements, off-white/dark dual theme with a manual toggle
- Ship the site on Cloudflare Workers (static assets) with `chroju.dev` as a custom domain, replacing Vercel

## Changes

- **Build pipeline** (`src/build.ts`): remark-gfm + rehype-raw + Shiki (build-time dual-theme highlighting), link cards via a custom remark plugin with a committed OGP cache (`.cache/linkcards.json`), full-content RSS, sitemap.xml, llms.txt, JSON-LD (`BlogPosting` + `BreadcrumbList`)
- **OGP images**: generated locally at build time with satori + resvg (Noto Sans JP), replacing the external og-image.chroju.dev service
- **Article footer**: a single bar with an IDE-style breadcrumb (`chroju.dev / blog / {slug}.md`, with a recent-posts dropdown) on the left and Raw/copy/edit actions on the right, replacing the old plain footer links
- **Raw markdown**: each post's source is served at `/blog/{slug}.md` (text/plain via generated `_headers`)
- **Accessibility**: 18px root scaling, WCAG AA contrast in both themes, focus-visible outlines, skip link, reduced-motion support, 44px touch targets
- **PWA removed**: `sw.js` is replaced with a self-destructing kill switch (do not delete it)
- **Drafts**: `draft: true` posts are fully excluded from the build
- **CI/CD**: PR builds with output integrity verification (`npm run check`), deploy to Cloudflare Workers on merge to main, all Actions pinned to commit SHAs
- **Fixed a live bug**: a stray U+0008 control character made the production feed.xml malformed for strict XML parsers; content is now sanitized at feed generation

## Test Plan

- [x] `npx tsc --noEmit` and `npm run check` pass (270 published posts, 102 tags, feed well-formed)
- [x] Verified on the workers.dev preview: trailing-slash redirects, `.md` content types (including the `.md`-suffixed slug edge case), Japanese/space tag pages, OGP images, 404
- [x] `chroju.dev` cut over to the Worker; `www.chroju.dev` 301s to the apex including query strings
- [x] Manually reviewed the article footer breadcrumb and action row across desktop/mobile, light/dark

🤖 Generated with [Claude Code](https://claude.com/claude-code)