### PR TITLE
fix(build): Set explicit charset on llms.txt Content-Type

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -106,7 +106,14 @@ export async function buildAll(options: BuildOptions = {}): Promise<void> {
 
   // .md はブラウザでインライン表示できるよう text/plain で配信する。
   // slug自体が .md で終わる記事のHTMLページはグロブに巻き込まれるため個別に戻す
-  const headerRules = ['/blog/*.md', '  Content-Type: text/plain; charset=utf-8']
+  const headerRules = [
+    '/blog/*.md',
+    '  Content-Type: text/plain; charset=utf-8',
+    '',
+    // Cloudflareのデフォルト拡張子マッピングはcharset未指定でmojibakeの原因になる
+    '/llms.txt',
+    '  Content-Type: text/plain; charset=utf-8',
+  ]
   for (const id of mdSlugPosts) {
     headerRules.push('', `/blog/${encodeURI(id)}`, '  ! Content-Type', '  Content-Type: text/html; charset=utf-8')
   }


### PR DESCRIPTION
## Summary

- `llms.txt` was served as `Content-Type: text/plain` with no charset (Cloudflare's default extension mapping), which garbled the Japanese text in browsers without a UTF-8 locale hint
- Add an explicit `_headers` rule for `/llms.txt`, mirroring the existing rule for `/blog/*.md`

## Test Plan

- [x] `npm run build` && `npm run check` pass
- [ ] After deploy: confirm `curl -sI https://chroju.dev/llms.txt` returns `Content-Type: text/plain; charset=utf-8` and the page renders correctly in-browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)