### PR TITLE
記事本文にtext-autospaceを適用

### DIFF
--- a/styles/site.css
+++ b/styles/site.css
@@ -341,6 +341,12 @@ h3 {
   }
 }
 
+p,
+main ul,
+main ol {
+  text-autospace: normal;
+}
+
 p {
   margin: 1.75rem 0;
 }


### PR DESCRIPTION
## Summary
- 記事本文の段落・リスト（p, ul, ol）に `text-autospace: normal` を追加し、和文・欧文混在時に自動で八分アキを挿入する

## 参考
- https://engineers.ntt.com/entry/202607-introduce-text-autospace/entry

## Test plan
- [x] `npm run dev` でローカルプレビューし、記事本文の表示を目視確認